### PR TITLE
Update to Beacon API 0.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dnastack</groupId>
     <artifactId>beacon-adapter-api</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -27,15 +27,20 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.ga4gh</groupId>
-            <artifactId>beacon</artifactId>
-            <version>0.3.0</version>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.14.8</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>openapi-generator-maven-plugin</artifactId>
+            <version>3.0.3</version>
         </dependency>
     </dependencies>
 
@@ -54,6 +59,31 @@
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>
                 <version>1.14.8.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>3.0.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>https://raw.githubusercontent.com/ga4gh-beacon/specification/v0.4.2/beacon.yaml</inputSpec>
+                            <generatorName>java</generatorName>
+                            <generateApis>false</generateApis>
+                            <modelPackage>org.ga4gh.beacon</modelPackage>
+                            <generateSupportingFiles>false</generateSupportingFiles>
+                            <generateModelDocumentation>false</generateModelDocumentation>
+                            <configOptions>
+                                <sourceFolder>src/gen/java/main</sourceFolder>
+                                <java8>true</java8>
+                                <dateLibrary>java8</dateLibrary>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/dnastack/beacon/adapter/api/BeaconAdapter.java
+++ b/src/main/java/com/dnastack/beacon/adapter/api/BeaconAdapter.java
@@ -60,19 +60,25 @@ public interface BeaconAdapter {
      *
      * @param referenceName           name of the reference
      * @param start                   start position
+     * @param startMin                minimum start coordinate
+     * @param startMax                maximum start coordinate
+     * @param end                     precise end coordinate
+     * @param endMin                  minimum end coordinate
+     * @param endMax                  maximum end coordinate
      * @param referenceBases          reference bases
      * @param alternateBases          alternate bases
+     * @param variantType             used to denote structural variants
      * @param assemblyId              genome assembly
      * @param datasetIds              list of datasetIds
-     * @param includeDatasetResponses include
+     * @param includeDatasetResponses include datasets to response object
      * @return beacon allele response
      */
-    BeaconAlleleResponse getBeaconAlleleResponse(Chromosome referenceName, Long start, String referenceBases, String alternateBases, String assemblyId, List<String> datasetIds, BeaconAlleleRequest.IncludeDatasetResponsesEnum includeDatasetResponses) throws BeaconException;
+    BeaconAlleleResponse getBeaconAlleleResponse(Chromosome referenceName, Long start, Long startMin, Long startMax, Long end, Long endMin, Long endMax, String referenceBases, String alternateBases, String variantType, String assemblyId, List<String> datasetIds, BeaconAlleleRequest.IncludeDatasetResponsesEnum includeDatasetResponses) throws BeaconException;
 
     /**
      * Retrieve information about the specified beacon
      *
-     * @return beacon infroamtion
+     * @return beacon information
      */
     Beacon getBeacon() throws BeaconException;
 

--- a/src/main/java/com/dnastack/beacon/adapter/api/BeaconAdapter.java
+++ b/src/main/java/com/dnastack/beacon/adapter/api/BeaconAdapter.java
@@ -73,7 +73,7 @@ public interface BeaconAdapter {
      * @param includeDatasetResponses include datasets to response object
      * @return beacon allele response
      */
-    BeaconAlleleResponse getBeaconAlleleResponse(Chromosome referenceName, Long start, Long startMin, Long startMax, Long end, Long endMin, Long endMax, String referenceBases, String alternateBases, String variantType, String assemblyId, List<String> datasetIds, BeaconAlleleRequest.IncludeDatasetResponsesEnum includeDatasetResponses) throws BeaconException;
+    BeaconAlleleResponse getBeaconAlleleResponse(Chromosome referenceName, Long start, Integer startMin, Integer startMax, Integer end, Integer endMin, Integer endMax, String referenceBases, String alternateBases, String variantType, String assemblyId, List<String> datasetIds, BeaconAlleleRequest.IncludeDatasetResponsesEnum includeDatasetResponses) throws BeaconException;
 
     /**
      * Retrieve information about the specified beacon

--- a/src/main/java/com/dnastack/beacon/adapter/api/BeaconAdapter.java
+++ b/src/main/java/com/dnastack/beacon/adapter/api/BeaconAdapter.java
@@ -41,7 +41,7 @@ public interface BeaconAdapter {
     /**
      * Initialization method for creating and configuring this new adapter
      *
-     * @param config
+     * @param config adapter configuration
      */
     void initAdapter(AdapterConfig config);
 
@@ -66,7 +66,7 @@ public interface BeaconAdapter {
      * @param includeDatasetResponses include
      * @return beacon allele response
      */
-    BeaconAlleleResponse getBeaconAlleleResponse(String referenceName, Long start, String referenceBases, String alternateBases, String assemblyId, List<String> datasetIds, Boolean includeDatasetResponses) throws BeaconException;
+    BeaconAlleleResponse getBeaconAlleleResponse(String referenceName, Long start, String referenceBases, String alternateBases, String assemblyId, List<String> datasetIds, BeaconAlleleRequest.IncludeDatasetResponsesEnum includeDatasetResponses) throws BeaconException;
 
     /**
      * Retrieve information about the specified beacon

--- a/src/main/java/com/dnastack/beacon/adapter/api/BeaconAdapter.java
+++ b/src/main/java/com/dnastack/beacon/adapter/api/BeaconAdapter.java
@@ -28,6 +28,7 @@ import com.dnastack.beacon.utils.AdapterConfig;
 import org.ga4gh.beacon.Beacon;
 import org.ga4gh.beacon.BeaconAlleleRequest;
 import org.ga4gh.beacon.BeaconAlleleResponse;
+import org.ga4gh.beacon.Chromosome;
 
 import java.util.List;
 
@@ -66,7 +67,7 @@ public interface BeaconAdapter {
      * @param includeDatasetResponses include
      * @return beacon allele response
      */
-    BeaconAlleleResponse getBeaconAlleleResponse(String referenceName, Long start, String referenceBases, String alternateBases, String assemblyId, List<String> datasetIds, BeaconAlleleRequest.IncludeDatasetResponsesEnum includeDatasetResponses) throws BeaconException;
+    BeaconAlleleResponse getBeaconAlleleResponse(Chromosome referenceName, Long start, String referenceBases, String alternateBases, String assemblyId, List<String> datasetIds, BeaconAlleleRequest.IncludeDatasetResponsesEnum includeDatasetResponses) throws BeaconException;
 
     /**
      * Retrieve information about the specified beacon


### PR DESCRIPTION
Replaced original Protobuf classes with OpenAPI/Swagger to generate model classes of GA4GH Beacon API version 0.4.2.